### PR TITLE
Fix scroll refs when cleaning battle

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dnd-battle-tracker",
-  "version": "5.26.2",
+  "version": "5.26.3",
   "private": true,
   "dependencies": {
     "@apollo/client": "^3.7.9",

--- a/src/components/page/Creatures.js
+++ b/src/components/page/Creatures.js
@@ -24,10 +24,12 @@ function Creatures({
     forwardedRef,
     () => ({
       scrollToCreature: (value) => {
-        refs[value].current.scrollIntoView({
-          behavior: 'smooth',
-          block: 'center',
-        });
+        if (refs[value]?.current) {
+          refs[value].current.scrollIntoView({
+            behavior: 'smooth',
+            block: 'center',
+          });
+        }
       },
     }),
     [refs],


### PR DESCRIPTION
I reproduced this locally, don't know how it behaves live.

When I clean a battle with saved characters, the app will crash because of this.

<img width="868" alt="Screenshot 2023-03-23 at 16 42 30" src="https://user-images.githubusercontent.com/9382283/227244270-d30d96cc-7ea6-4c1c-b7aa-744dd616db15.png">
